### PR TITLE
fix: respect terminal cell widths in highlight and cursor rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.10
+
+- Fix wide-character cell widths being ignored in highlight and cursor rendering
+  - `applyHighlightsToLine` and `applyCursorToLine` now track positions using terminal cell widths instead of JS string length
+  - Text after double-width characters (CJK, etc.) can now be highlighted and cursored correctly
+  - Cell widths measured via `wcwidth` (new dependency), so this works in both Bun and Node.js
+  - `convertSpanToChunk` now preserves `span.width` as `cellWidth` on chunks
+
 ## 1.4.9
 
 - Fix CI stability for `bun test`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostty-opentui",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "type": "module",
   "description": "Fast ANSI/VT terminal parser powered by Ghostty's Zig terminal emulation library",
   "scripts": {
@@ -73,6 +73,7 @@
     "@takumi-rs/helpers": "^0.65.0"
   },
   "dependencies": {
-    "strip-ansi": "^7.1.2"
+    "strip-ansi": "^7.1.2",
+    "wcwidth": "^1.0.1"
   }
 }

--- a/src/highlight.test.ts
+++ b/src/highlight.test.ts
@@ -159,6 +159,24 @@ describe("terminalDataToStyledText with highlights", () => {
     expect(helloChunk).toBeDefined()
   })
 
+  test("should highlight text after a wide character using cell columns", () => {
+    const data = ptyToJson("A東B", { cols: 80, rows: 24 })
+    const highlights: HighlightRegion[] = [
+      { line: 0, start: 3, end: 4, backgroundColor: "#ff0000" },
+    ]
+
+    const styled = terminalDataToStyledText(data, highlights)
+    const highlightedB = styled.chunks.find(
+      (c) => c.text === "B" && toHex(c.bg) === "#ff0000"
+    )
+    const highlightedWide = styled.chunks.find(
+      (c) => c.text.includes("東") && toHex(c.bg) === "#ff0000"
+    )
+
+    expect(highlightedB).toBeDefined()
+    expect(highlightedWide).toBeUndefined()
+  })
+
   test("should handle multiple highlights on different lines", () => {
     const ansi = "first line\nsecond line\nthird line"
     const data = ptyToJson(ansi, { cols: 80, rows: 24 })
@@ -177,6 +195,18 @@ describe("terminalDataToStyledText with highlights", () => {
     )
     expect(firstChunk).toBeDefined()
     expect(thirdChunk).toBeDefined()
+  })
+
+  test("should apply cursor after highlight on the same line", () => {
+    const ansi = "hello world"
+    const data = ptyToJson(ansi, { cols: 80, rows: 24 })
+    const highlights: HighlightRegion[] = [
+      { line: 0, start: 0, end: 5, backgroundColor: "#ff0000" },
+    ]
+    // Cursor at column 6 (on "w") — after the highlight split
+    const styled = terminalDataToStyledText(data, highlights, { x: 6, y: 0, style: "block" })
+    const texts = styled.chunks.filter((c) => c.text !== "\n" && c.text !== " ").map((c) => c.text)
+    expect(texts.join("")).toContain("world")
   })
 
   test("should work with no highlights", () => {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -190,6 +190,32 @@ describe("terminalDataToStyledText highlights", () => {
     )
     expect(highlightedChunk).toBeDefined()
   })
+
+  it("should place the cursor on the correct cell after a wide character", () => {
+    const data = ptyToJson("A東B\x1b[D", { cols: 80, rows: 24 })
+    const styled = terminalDataToStyledText(data, undefined, {
+      x: data.cursor[0],
+      y: data.cursor[1],
+      style: "block",
+    })
+
+    const firstNewline = styled.chunks.findIndex((chunk) => chunk.text === "\n")
+    const firstLineText = styled.chunks
+      .slice(0, firstNewline >= 0 ? firstNewline : undefined)
+      .map((chunk) => chunk.text)
+      .join("")
+    expect(firstLineText).toBe("A東B")
+
+    const cursorChunk = styled.chunks.find(
+      (c) => c.text === "B" && c.bg && rgbToHex(c.bg) === "#d4d4d4"
+    )
+    const trailingCursor = styled.chunks.find(
+      (c) => c.text === " " && c.bg && rgbToHex(c.bg) === "#d4d4d4"
+    )
+
+    expect(cursorChunk).toBeDefined()
+    expect(trailingCursor).toBeUndefined()
+  })
 })
 
 describe("ptyToText", () => {

--- a/src/terminal-buffer.ts
+++ b/src/terminal-buffer.ts
@@ -7,9 +7,32 @@ import {
   type TextChunk,
 } from "@opentui/core"
 import { ptyToJson, PersistentTerminal, hasPersistentTerminalSupport, type TerminalData, type TerminalSpan, StyleFlags } from "./ffi.js"
+import wcwidth from "wcwidth"
 
 const DEFAULT_FG = RGBA.fromHex("#d4d4d4")
 const DEFAULT_BG = RGBA.fromHex("#1e1e1e")
+
+type WidthAwareChunk = TextChunk & {
+  cellWidth: number
+}
+
+function getChunkCellWidth(chunk: TextChunk): number {
+  return "cellWidth" in chunk && typeof (chunk as WidthAwareChunk).cellWidth === "number"
+    ? (chunk as WidthAwareChunk).cellWidth
+    : wcwidth(chunk.text)
+}
+
+function cellColToStringIndex(text: string, cellCol: number): number {
+  if (cellCol <= 0) return 0
+  let col = 0
+  let strIdx = 0
+  for (const ch of text) {
+    if (col >= cellCol) break
+    col += wcwidth(ch)
+    strIdx += ch.length
+  }
+  return strIdx
+}
 
 /**
  * Defines a region to highlight in the terminal output.
@@ -47,8 +70,8 @@ function getLineStarts(lineInfo: LineInfoWithStarts): number[] {
   return lineInfo.lineStarts ?? lineInfo.lineStartCols ?? []
 }
 
-function convertSpanToChunk(span: TerminalSpan): TextChunk {
-  const { text, fg, bg, flags } = span
+function convertSpanToChunk(span: TerminalSpan): WidthAwareChunk {
+  const { text, fg, bg, flags, width } = span
 
   let fgColor = fg ? RGBA.fromHex(fg) : DEFAULT_FG
   let bgColor = bg ? RGBA.fromHex(bg) : undefined
@@ -66,7 +89,7 @@ function convertSpanToChunk(span: TerminalSpan): TextChunk {
   if (flags & StyleFlags.STRIKETHROUGH) attributes |= TextAttributes.STRIKETHROUGH
   if (flags & StyleFlags.FAINT) attributes |= TextAttributes.DIM
 
-  return { __isChunk: true, text, fg: fgColor, bg: bgColor, attributes }
+  return { __isChunk: true, text, fg: fgColor, bg: bgColor, attributes, cellWidth: width }
 }
 
 /**
@@ -83,68 +106,56 @@ export function applyHighlightsToLine(
   let col = 0
 
   for (const chunk of chunks) {
+    const w = getChunkCellWidth(chunk)
     const chunkStart = col
-    const chunkEnd = col + chunk.text.length
+    const chunkEnd = col + w
 
     // Find all highlights that overlap with this chunk
-    const overlappingHighlights = highlights.filter(
-      (hl) => hl.start < chunkEnd && hl.end > chunkStart
-    )
+    const overlapping = highlights
+      .filter((hl) => hl.start < chunkEnd && hl.end > chunkStart)
+      .sort((a, b) => a.start - b.start)
 
-    if (overlappingHighlights.length === 0) {
-      // No highlights overlap this chunk
+    if (overlapping.length === 0) {
       result.push(chunk)
       col = chunkEnd
       continue
     }
 
-    // Process the chunk with highlights
-    let pos = 0
-    const text = chunk.text
+    // Split chunk at highlight boundaries
+    let cellPos = 0
 
-    // Sort highlights by start position
-    const sortedHighlights = [...overlappingHighlights].sort((a, b) => a.start - b.start)
+    for (const hl of overlapping) {
+      const hlStartLocal = Math.max(0, hl.start - chunkStart)
+      const hlEndLocal = Math.min(w, hl.end - chunkStart)
 
-    for (const hl of sortedHighlights) {
-      const hlStartInChunk = Math.max(0, hl.start - chunkStart)
-      const hlEndInChunk = Math.min(text.length, hl.end - chunkStart)
-
-      // Add text before highlight (if any)
-      if (pos < hlStartInChunk) {
-        result.push({
-          __isChunk: true,
-          text: text.slice(pos, hlStartInChunk),
-          fg: chunk.fg,
-          bg: chunk.bg,
-          attributes: chunk.attributes,
-        })
+      // Text before highlight
+      if (cellPos < hlStartLocal) {
+        const startStr = cellColToStringIndex(chunk.text, cellPos)
+        const endStr = cellColToStringIndex(chunk.text, hlStartLocal)
+        result.push({ ...chunk, text: chunk.text.slice(startStr, endStr), cellWidth: hlStartLocal - cellPos } as TextChunk)
       }
 
-      // Add highlighted text
-      if (hlStartInChunk < hlEndInChunk) {
-        const highlightedText = text.slice(hlStartInChunk, hlEndInChunk)
-        const displayText = hl.replaceWithX ? "x".repeat(highlightedText.length) : highlightedText
+      // Highlighted text
+      if (hlStartLocal < hlEndLocal) {
+        const startStr = cellColToStringIndex(chunk.text, hlStartLocal)
+        const endStr = cellColToStringIndex(chunk.text, hlEndLocal)
+        const hlText = chunk.text.slice(startStr, endStr)
+        const cellWidth = hlEndLocal - hlStartLocal
         result.push({
-          __isChunk: true,
-          text: displayText,
-          fg: chunk.fg,
+          ...chunk,
+          text: hl.replaceWithX ? "x".repeat(cellWidth) : hlText,
           bg: RGBA.fromHex(hl.backgroundColor),
-          attributes: chunk.attributes,
-        })
+          cellWidth,
+        } as TextChunk)
       }
 
-      pos = hlEndInChunk
+      cellPos = hlEndLocal
     }
 
-    // Add remaining text after last highlight
-    if (pos < text.length) {
-      result.push({
-        __isChunk: true,
-        text: text.slice(pos),
-        fg: chunk.fg,
-        bg: chunk.bg,
-        attributes: chunk.attributes,
-      })
+    // Text after last highlight
+    if (cellPos < w) {
+      const startStr = cellColToStringIndex(chunk.text, cellPos)
+      result.push({ ...chunk, text: chunk.text.slice(startStr), cellWidth: w - cellPos } as TextChunk)
     }
 
     col = chunkEnd
@@ -167,7 +178,9 @@ function makeCursorChunk(
   char: string,
   style: "block" | "underline",
   original?: TextChunk,
-): TextChunk {
+): WidthAwareChunk {
+  const cellWidth = Math.max(1, wcwidth(char))
+
   if (style === "block") {
     return {
       __isChunk: true,
@@ -175,6 +188,7 @@ function makeCursorChunk(
       fg: original?.bg || RGBA.fromHex("#1e1e1e"),
       bg: original?.fg || DEFAULT_FG,
       attributes: original?.attributes ?? 0,
+      cellWidth,
     }
   }
   return {
@@ -183,6 +197,7 @@ function makeCursorChunk(
     fg: original?.fg || DEFAULT_FG,
     bg: original?.bg,
     attributes: (original?.attributes ?? 0) | TextAttributes.UNDERLINE,
+    cellWidth,
   }
 }
 
@@ -196,13 +211,13 @@ function applyCursorToLine(
   cursorX: number,
   cursorStyle: "block" | "underline",
 ): TextChunk[] {
-  const totalLen = chunks.reduce((sum, c) => sum + c.text.length, 0)
+  const totalLen = chunks.reduce((sum, chunk) => sum + getChunkCellWidth(chunk), 0)
 
   // Cursor beyond line content - pad with spaces then append cursor
   if (cursorX >= totalLen) {
     const gap = cursorX - totalLen
     if (gap > 0) {
-      return [...chunks, { __isChunk: true, text: " ".repeat(gap), attributes: 0 } as TextChunk, makeCursorChunk(" ", cursorStyle)]
+      return [...chunks, { __isChunk: true, text: " ".repeat(gap), attributes: 0, cellWidth: gap } as WidthAwareChunk, makeCursorChunk(" ", cursorStyle)]
     }
     return [...chunks, makeCursorChunk(" ", cursorStyle)]
   }
@@ -212,22 +227,21 @@ function applyCursorToLine(
   let col = 0
 
   for (const chunk of chunks) {
-    const chunkEnd = col + chunk.text.length
+    const w = getChunkCellWidth(chunk)
+    const chunkEnd = col + w
 
     if (cursorX >= col && cursorX < chunkEnd) {
-      const pos = cursorX - col
+      const localCol = cursorX - col
+      const strIdx = cellColToStringIndex(chunk.text, localCol)
+      const cursorChar = String.fromCodePoint(chunk.text.codePointAt(strIdx)!)
+      const strEnd = strIdx + cursorChar.length
 
-      // Text before cursor
-      if (pos > 0) {
-        result.push({ ...chunk, text: chunk.text.slice(0, pos) })
+      if (strIdx > 0) {
+        result.push({ ...chunk, text: chunk.text.slice(0, strIdx) })
       }
-
-      // Cursor character
-      result.push(makeCursorChunk(chunk.text[pos], cursorStyle, chunk))
-
-      // Text after cursor
-      if (pos + 1 < chunk.text.length) {
-        result.push({ ...chunk, text: chunk.text.slice(pos + 1) })
+      result.push(makeCursorChunk(cursorChar, cursorStyle, chunk))
+      if (strEnd < chunk.text.length) {
+        result.push({ ...chunk, text: chunk.text.slice(strEnd) })
       }
     } else {
       result.push(chunk)


### PR DESCRIPTION
applyHighlightsToLine() and applyCursorToLine() tracked column positions using chunk.text.length (JS string length), but HighlightRegion start/end and cursor positions are in terminal cell columns. Wide characters (CJK, etc.) occupy 2 cells but are 1 JS char, causing highlights and cursor to land on the wrong text.

Add getChunkCellWidth() and cellColToStringIndex() helpers using wcwidth for portable cell-width measurement. convertSpanToChunk() now preserves span.width as cellWidth on chunks, and split chunks get recomputed cellWidth so cursor rendering after highlights sees correct column widths.

FWIW I'm fixing wide char stuff in OpenTUI as well -- see https://github.com/anomalyco/opentui/pull/791.

Before:

<img width="1354" height="966" alt="wide-character-highlight-fix-before" src="https://github.com/user-attachments/assets/3dba7277-535e-4001-8892-2101cd2c17ab" />

After:

<img width="1354" height="966" alt="wide-character-highlight-fix-after" src="https://github.com/user-attachments/assets/8c2eb953-3388-47c4-9ddd-bb50dee7e728" />

Demo script:

```
#!/usr/bin/env bun

/**
 * Demonstrates the wide-character highlight misalignment bug in
 * ghostty-opentui's applyHighlightsToLine().
 *
 * The function tracks column positions using chunk.text.length (JS string
 * length) but HighlightRegion start/end are in terminal cell columns.
 * For wide characters like CJK (2 cells, 1 JS char), these diverge.
 *
 * Usage: bun repro-highlight.ts
 */

import { applyHighlightsToLine, type HighlightRegion } from "ghostty-opentui/terminal-buffer"
import { RGBA, type TextChunk, rgbToHex } from "@opentui/core"
import wcwidth from "wcwidth"

const HIGHLIGHT_COLOR = "#ff0000"

// ANSI escapes for terminal rendering
const RESET = "\x1b[0m"
const DIM = "\x1b[2m"
const BOLD = "\x1b[1m"
const BG_GREEN = "\x1b[42;30m"  // green bg, black fg — expected highlight
const BG_RED = "\x1b[41;97m"    // red bg, white fg — actual highlight

function hex(rgba: RGBA | undefined): string | undefined {
  return rgba ? rgbToHex(rgba) : undefined
}

function createChunk(text: string): TextChunk {
  return { __isChunk: true, text, fg: RGBA.fromHex("#ffffff"), bg: undefined, attributes: 0 }
}

/**
 * Renders a string into a cell grid where each cell is one fixed-width column.
 * Wide characters occupy two adjacent cells (char + spacer).
 * Returns an array of cell strings, each representing one terminal column.
 */
function toCellGrid(text: string): string[] {
  const cells: string[] = []
  for (const ch of text) {
    const w = wcwidth(ch)
    cells.push(ch)
    for (let i = 1; i < w; i++) cells.push("") // spacer cells
  }
  return cells
}

/**
 * Render a cell grid as a visual row with ANSI highlights applied.
 * Each cell gets a fixed-width 3-char slot so columns stay aligned.
 * highlightedCells: set of cell indices that should be colored.
 */
function renderRow(cells: string[], highlightedCells: Set<number>, bgEscape: string): string {
  let out = ""
  for (let i = 0; i < cells.length; i++) {
    const ch = cells[i]
    const lit = highlightedCells.has(i)
    if (ch === "") continue // skip spacer cells (already printed as part of wide char)
    out += lit ? ` ${bgEscape}${ch}${RESET}` : ` ${ch}`
  }
  return out
}

/**
 * Given the chunks returned by applyHighlightsToLine, figure out which
 * original-text JS character indices got highlighted.
 */
function highlightedCharIndices(original: string, resultChunks: TextChunk[]): Set<number> {
  const indices = new Set<number>()
  let pos = 0
  for (const chunk of resultChunks) {
    const isLit = hex(chunk.bg) === HIGHLIGHT_COLOR
    for (const ch of chunk.text) {
      if (isLit) indices.add(pos)
      pos++
    }
  }
  return indices
}

/**
 * Convert JS char indices into terminal cell indices.
 */
function charIndicesToCellIndices(text: string, charIdxs: Set<number>): Set<number> {
  const cellIdxs = new Set<number>()
  let cell = 0
  let ci = 0
  for (const ch of text) {
    const w = wcwidth(ch)
    if (charIdxs.has(ci)) {
      for (let j = 0; j < w; j++) cellIdxs.add(cell + j)
    }
    cell += w
    ci++
  }
  return cellIdxs
}

/**
 * Build the expected set of highlighted cell indices from the highlight region.
 */
function expectedCellIndices(start: number, end: number): Set<number> {
  const s = new Set<number>()
  for (let i = start; i < end; i++) s.add(i)
  return s
}

// ─────────────────────────────────────────────────────────────────────────────

interface TestCase {
  label: string
  text: string
  /** Highlight region in terminal cell columns [start, end) */
  start: number
  end: number
  /** What we want highlighted (for the description) */
  target: string
}

const tests: TestCase[] = [
  {
    label: "Highlight 'B' after a wide char",
    text: "A東B",
    start: 3, end: 4,
    target: "B",
  },
  {
    label: "Highlight the wide char '東' itself",
    text: "A東B",
    start: 1, end: 3,
    target: "東",
  },
  {
    label: "Highlight 'X' after two wide chars",
    text: "東世X",
    start: 4, end: 5,
    target: "X",
  },
  {
    label: "Highlight 'ok' in mixed content",
    text: "日本語ok",
    start: 6, end: 8,
    target: "ok",
  },
]

console.log()
console.log(`${BOLD}Wide-character highlight misalignment repro${RESET}`)
console.log()
console.log(`The highlight API specifies regions in terminal cell columns,`)
console.log(`but applyHighlightsToLine() tracks positions with JS string length.`)
console.log(`Wide chars (2 cells, 1 JS char) cause every subsequent column to`)
console.log(`shift, so highlights land on the wrong text.`)

let anyFailed = false

for (const t of tests) {
  console.log()
  console.log(`${BOLD}── ${t.label} ──${RESET}`)

  // Show the cell layout
  const cells = toCellGrid(t.text)
  const totalCells = cells.length

  // Column numbers
  let numRow = "  "
  for (let i = 0; i < totalCells; i++) {
    if (cells[i] === "") continue
    const w = wcwidth(cells[i])
    numRow += ` ${String(i).padEnd(w, " ")}`
  }
  console.log(`${DIM}cell:     ${numRow}${RESET}`)

  // Text row
  let textRow = "  "
  for (let i = 0; i < totalCells; i++) {
    if (cells[i] === "") continue
    const w = wcwidth(cells[i])
    textRow += ` ${cells[i].padEnd(w, " ")}`
  }
  console.log(`text:     ${textRow}`)
  console.log(`${DIM}request:  highlight cells ${t.start}–${t.end - 1} (= '${t.target}')${RESET}`)

  // Run the buggy code
  const chunks = [createChunk(t.text)]
  const highlights: HighlightRegion[] = [
    { line: 0, start: t.start, end: t.end, backgroundColor: HIGHLIGHT_COLOR },
  ]
  const result = applyHighlightsToLine(chunks, highlights)

  // What actually got highlighted
  const litCharIdxs = highlightedCharIndices(t.text, result)
  const actualCellIdxs = charIndicesToCellIndices(t.text, litCharIdxs)
  const expectCellIdxs = expectedCellIndices(t.start, t.end)

  const expectedRow = renderRow(cells, expectCellIdxs, BG_GREEN)
  const actualRow = renderRow(cells, actualCellIdxs, BG_RED)

  console.log(`${BG_GREEN} expected ${RESET}${expectedRow}`)
  console.log(`${BG_RED} actual   ${RESET}${actualRow}`)

  const match = [...expectCellIdxs].every(i => actualCellIdxs.has(i)) &&
                [...actualCellIdxs].every(i => expectCellIdxs.has(i))
  if (!match) anyFailed = true
}

console.log()
if (anyFailed) {
  console.log(`${BG_RED} BUG ${RESET} Highlights are misaligned after wide characters.`)
  process.exit(1)
} else {
  console.log("All highlights aligned correctly.")
}
```