### PR TITLE
fix: preserve full grapheme clusters in cell output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.11
+
+- Preserve full grapheme clusters in `writeJsonOutput`
+  - Cells flagged with `content_tag == .codepoint_grapheme` (ZWJ sequences, VS16 emoji, regional-indicator flag pairs, skin-tone modifiers) used to lose every codepoint past the first, because the exporter wrote only `cell.codepoint()` and never consulted `pin.grapheme(cell)`. Span `width` was correct but `text` was truncated, so consumers rendered just the leading codepoint where the user expected the full cluster.
+  - Cell text is now built via a new `appendCellText` helper that writes the base codepoint and then iterates `pin.grapheme(cell)` for any extras.
+  - Added a regression test covering VS16, ZWJ, and flag-pair input under mode 2027.
+
 ## 1.4.10
 
 - Fix wide-character cell widths being ignored in highlight and cursor rendering

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostty-opentui",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "type": "module",
   "description": "Fast ANSI/VT terminal parser powered by Ghostty's Zig terminal emulation library",
   "scripts": {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -86,6 +86,23 @@ describe("ptyToJson", () => {
     expect(result.rows).toBe(50)
   })
 
+  it("should preserve multi-codepoint grapheme clusters", () => {
+    const samples = [
+      { input: "♥️X", width: 3 },
+      { input: "👨‍👩‍👧‍👦X", width: 3 },
+      { input: "🇺🇸X", width: 3 },
+    ]
+
+    for (const { input, width } of samples) {
+      const result = ptyToJson(`\x1b[?2027h${input}`, { cols: 20, rows: 2 })
+      const text = result.lines[0].spans.map((s) => s.text).join("")
+      const cellWidth = result.lines[0].spans.reduce((sum, s) => sum + s.width, 0)
+
+      expect(text).toBe(input)
+      expect(cellWidth).toBe(width)
+    }
+  })
+
   it("should handle tab expansion correctly", () => {
     // Tab character followed by colored text
     // Tab should expand to spaces and be included in the span, not break it

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -122,6 +122,24 @@ fn writeColor(writer: anytype, rgb: ?color.RGB) !void {
     }
 }
 
+fn appendUtf8Codepoint(buf: []u8, text_len: *usize, cp: u21) void {
+    const len = std.unicode.utf8CodepointSequenceLength(cp) catch return;
+    if (text_len.* + len > buf.len) return;
+
+    _ = std.unicode.utf8Encode(cp, buf[text_len.*..]) catch return;
+    text_len.* += len;
+}
+
+fn appendCellText(buf: []u8, text_len: *usize, cell: *const pagepkg.Cell, pin: ghostty_vt.Pin, cp: u21) void {
+    appendUtf8Codepoint(buf, text_len, cp);
+
+    if (cell.content_tag != .codepoint_grapheme) return;
+    const grapheme = pin.grapheme(cell) orelse return;
+    for (grapheme) |extra_cp| {
+        appendUtf8Codepoint(buf, text_len, extra_cp);
+    }
+}
+
 /// Count total lines in terminal screen
 fn countLines(screen: *Screen) usize {
     var total: usize = 0;
@@ -264,11 +282,7 @@ pub fn writeJsonOutput(
             }
 
             const cp21: u21 = @intCast(cp);
-            const len = std.unicode.utf8CodepointSequenceLength(cp21) catch 1;
-            if (text_len + len <= text_buf.len) {
-                _ = std.unicode.utf8Encode(cp21, text_buf[text_len..]) catch 0;
-                text_len += len;
-            }
+            appendCellText(text_buf[0..], &text_len, cell, pin, cp21);
 
             span_len += if (cell.wide == .wide) 2 else 1;
         }


### PR DESCRIPTION
writeJsonOutput emitted only the base codepoint of each cell via `cell.codepoint()`, discarding the extra codepoints ghostty-vt holds in its grapheme side-table for multi-codepoint clusters. Cells whose content_tag was `.codepoint_grapheme` — the marker ghostty-vt uses for ZWJ sequences, VS16 emoji presentation, regional-indicator flag pairs, and skin-tone modifiers — lost everything past the first codepoint. The exported `width` field stayed correct, but the `text` was truncated: a ZWJ family-emoji cluster shrank to its first emoji, an emoji-presented heart (U+2665 U+FE0F) became just U+2665, a regional-indicator flag pair became its leading half, and so on. Any consumer rendering the JSON would draw the first codepoint where the user expected the full cluster, and OpenTUI's text-buffer remeasure could return a cell count shorter than the row claimed, leaving stale-cell holes.

For cells flagged as grapheme clusters, iterate `pin.grapheme(cell)` as well and append each extra codepoint to the span text. Wrapped in a helper (`appendCellText`) so the call site stays small.  Adds a regression test covering VS16, ZWJ, and flag-pair input under mode 2027.

Before:

https://github.com/user-attachments/assets/50fdfe49-6d9e-4766-80ad-1f584c153a3b

After:

https://github.com/user-attachments/assets/7e53a516-03d4-4812-87eb-a425adcfe992

[Honeymux](https://github.com/honeymux/honeymux) I/O architecture diagram so you can see what I'm dealing with:

<img width="1249" height="886" alt="image" src="https://github.com/user-attachments/assets/99a2e9c3-ba80-4242-971f-d4c49b862d61" />
