### PR TITLE
fix: honor env-var overrides for bundled font paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.12
+
+- Honor env-var overrides for bundled font paths
+  - Bundled font lookup now honors GHOSTTY_OPENTUI_FONT_PATH and GHOSTTY_OPENTUI_FALLBACK_FONT_PATH env vars, fixing ENOENT errors when running bun --compile-built binaries on machines other than the build host.
+
 ## 1.4.11
 
 - Preserve full grapheme clusters in `writeJsonOutput`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostty-opentui",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "type": "module",
   "description": "Fast ANSI/VT terminal parser powered by Ghostty's Zig terminal emulation library",
   "scripts": {

--- a/src/image.ts
+++ b/src/image.ts
@@ -141,6 +141,8 @@ async function getRenderer(fontPath?: string): Promise<import("@takumi-rs/core")
 
 /** Resolve path to the bundled JetBrains Mono Nerd TTF */
 function getBundledFontPath(): string {
+  const override = process.env["GHOSTTY_OPENTUI_FONT_PATH"]
+  if (override) return override
   // import.meta.dirname works in both bun and node ESM
   const dir = typeof __dirname !== "undefined" ? __dirname : import.meta.dirname
   return join(dir, "..", "public", "jetbrains-mono-nerd.ttf")
@@ -148,6 +150,8 @@ function getBundledFontPath(): string {
 
 /** Resolve path to bundled fallback symbols font */
 function getBundledFallbackFontPath(): string {
+  const override = process.env["GHOSTTY_OPENTUI_FALLBACK_FONT_PATH"]
+  if (override) return override
   const dir = typeof __dirname !== "undefined" ? __dirname : import.meta.dirname
   return join(dir, "..", "public", "symbols-nerd-font-mono-regular.ttf")
 }


### PR DESCRIPTION
getBundledFontPath() and getBundledFallbackFontPath() compute their return values from import.meta.dirname, which bun --compile bakes in as the build host's absolute path. The compiled binary therefore tries to readFileSync a path that doesn't exist on the user's machine, and screenshots fail with ENOENT.

Add GHOSTTY_OPENTUI_FONT_PATH and GHOSTTY_OPENTUI_FALLBACK_FONT_PATH env vars so callers compiling with bun (or otherwise relocating the fonts) can redirect each lookup to a location they control. Mirrors the @takumi-rs/core NAPI_RS_NATIVE_LIBRARY_PATH pattern used for the NAPI binding in the same compile-mode scenario.

In use here:

https://github.com/honeymux/honeymux/blob/fe53e077bd5db8553ecbeffc11a6bb9cde6847c1/src/app/hooks/use-screenshot-workflow.ts#L285
