### PR TITLE
feat: add setBaseColorRemap hook for projecting palette colors

### DIFF
--- a/src/terminal-buffer.test.tsx
+++ b/src/terminal-buffer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, afterEach } from "bun:test"
 import { createRoot, extend } from "@opentui/react"
 import { createTestRenderer, type TestRendererOptions } from "@opentui/core/testing"
-import { GhosttyTerminalRenderable } from "./terminal-buffer.js"
+import { GhosttyTerminalRenderable, setBaseColorRemap } from "./terminal-buffer.js"
 import { act } from "react"
 import type { ReactNode } from "react"
 
@@ -944,6 +944,82 @@ drwx------  71 user  staff  2272 Nov 26 19:44 ..
       expect(() => ref.current?.feed("Data")).toThrow("persistent mode")
       expect(() => ref.current?.reset()).toThrow("persistent mode")
       expect(() => ref.current?.getCursor()).toThrow("persistent mode")
+    })
+  })
+
+  describe("setBaseColorRemap", () => {
+    afterEach(() => {
+      setBaseColorRemap(null)
+    })
+
+    // Walk every captured span and return the first one whose text contains
+    // `ch`.  Spans don't always include trailing whitespace, the renderer can
+    // collapse a row into multiple spans, and spans for "empty" cells often
+    // have no text at all — searching every line is more robust than
+    // assuming a fixed layout.
+    function findCharSpan(frame: ReturnType<typeof JSON.parse>, ch: string) {
+      for (const line of frame.lines) {
+        for (const span of line.spans) {
+          if (span.text && span.text.includes(ch)) return span
+        }
+      }
+      return undefined
+    }
+
+    it("rewrites span foreground colors that match a remap entry", async () => {
+      // ghostty-vt resolves \x1b[36m (palette index 6, "cyan") to its
+      // hardcoded Tomorrow Night cyan #8abeb7. Remap that to a saturated
+      // teal that a host terminal would have configured for ANSI cyan.
+      setBaseColorRemap(new Map([["#8abeb7", "#14a0a0"]]))
+
+      const { renderOnce, captureSpans } = await testRender(
+        <ghostty-terminal ansi={"\x1b[36mC\x1b[m"} cols={10} rows={2} style={{ width: 10, height: 2 }} />,
+        { width: 10, height: 2 },
+      )
+      await renderOnce()
+
+      const frame = captureSpans()
+      const span = findCharSpan(frame, "C")
+      expect(span).toBeDefined()
+      expect(span!.fg.r).toBeCloseTo(0x14 / 255, 2)
+      expect(span!.fg.g).toBeCloseTo(0xa0 / 255, 2)
+      expect(span!.fg.b).toBeCloseTo(0xa0 / 255, 2)
+    })
+
+    it("leaves span colors untouched when no remap is installed", async () => {
+      setBaseColorRemap(null)
+
+      const { renderOnce, captureSpans } = await testRender(
+        <ghostty-terminal ansi={"\x1b[36mC\x1b[m"} cols={10} rows={2} style={{ width: 10, height: 2 }} />,
+        { width: 10, height: 2 },
+      )
+      await renderOnce()
+
+      const frame = captureSpans()
+      const span = findCharSpan(frame, "C")
+      expect(span).toBeDefined()
+      // ghostty's hardcoded ANSI cyan is #8abeb7
+      expect(span!.fg.r).toBeCloseTo(0x8a / 255, 2)
+      expect(span!.fg.g).toBeCloseTo(0xbe / 255, 2)
+      expect(span!.fg.b).toBeCloseTo(0xb7 / 255, 2)
+    })
+
+    it("leaves colors that are not in the remap untouched", async () => {
+      // Remap only blue; cyan should pass through unchanged.
+      setBaseColorRemap(new Map([["#81a2be", "#1844a0"]]))
+
+      const { renderOnce, captureSpans } = await testRender(
+        <ghostty-terminal ansi={"\x1b[36mC\x1b[m"} cols={10} rows={2} style={{ width: 10, height: 2 }} />,
+        { width: 10, height: 2 },
+      )
+      await renderOnce()
+
+      const frame = captureSpans()
+      const span = findCharSpan(frame, "C")
+      expect(span).toBeDefined()
+      expect(span!.fg.r).toBeCloseTo(0x8a / 255, 2)
+      expect(span!.fg.g).toBeCloseTo(0xbe / 255, 2)
+      expect(span!.fg.b).toBeCloseTo(0xb7 / 255, 2)
     })
   })
 })

--- a/src/terminal-buffer.ts
+++ b/src/terminal-buffer.ts
@@ -12,6 +12,28 @@ import wcwidth from "wcwidth"
 const DEFAULT_FG = RGBA.fromHex("#d4d4d4")
 const DEFAULT_BG = RGBA.fromHex("#1e1e1e")
 
+let baseColorRemap: Map<string, string> | null = null
+
+/**
+ * Install a hex→hex remap that rewrites span foreground/background colors
+ * before they are converted to RGBA.
+ *
+ * ghostty-vt resolves palette-indexed colors (`\x1b[3Nm`, `\x1b[9Nm`,
+ * `\x1b[38;5;Nm` with N < 16) against its own hardcoded base 16 theme.
+ * Consumers that re-emit rendered chunks to a host terminal — e.g. an
+ * outer terminal multiplexer — usually want those palette indices to land
+ * in the *host's* user-configured palette instead.  This hook lets the
+ * consumer install a `Map<ghostty-hex, host-hex>` after probing the host
+ * via OSC 4, projecting ghostty's defaults onto the host's theme without
+ * any change to the underlying Zig palette.
+ *
+ * Hex strings must match the format produced by lib.zig's writeColor
+ * (lowercase, "#rrggbb"). Pass null to clear.
+ */
+export function setBaseColorRemap(remap: Map<string, string> | null): void {
+  baseColorRemap = remap
+}
+
 type WidthAwareChunk = TextChunk & {
   cellWidth: number
 }
@@ -73,8 +95,12 @@ function getLineStarts(lineInfo: LineInfoWithStarts): number[] {
 function convertSpanToChunk(span: TerminalSpan): WidthAwareChunk {
   const { text, fg, bg, flags, width } = span
 
-  let fgColor = fg ? RGBA.fromHex(fg) : DEFAULT_FG
-  let bgColor = bg ? RGBA.fromHex(bg) : undefined
+  const remap = baseColorRemap
+  const fgHex = fg && remap ? remap.get(fg) ?? fg : fg
+  const bgHex = bg && remap ? remap.get(bg) ?? bg : bg
+
+  let fgColor = fgHex ? RGBA.fromHex(fgHex) : DEFAULT_FG
+  let bgColor = bgHex ? RGBA.fromHex(bgHex) : undefined
 
   if (flags & StyleFlags.INVERSE) {
     const temp = fgColor


### PR DESCRIPTION
## Summary

ghostty-vt resolves palette-indexed SGR codes (`\x1b[3Nm`, `\x1b[9Nm`, `\x1b[38;5;Nm` with N < 16) against its own hardcoded base 16 palette before spans cross the FFI boundary. By the time the TS layer sees a span, the palette index is gone — only opaque RGB hex remains. There's no seam for a consumer to ask \"render those palette indices using *my* palette instead of yours.\"

That's a problem for any consumer that re-emits rendered chunks to a host terminal — e.g. an outer terminal multiplexer where the user has configured their own ANSI theme. Today, a fish prompt that emits `\x1b[36m` (cyan = palette index 6) renders as ghostty's hardcoded `#8abeb7` (Tomorrow Night cyan) regardless of what the host terminal's user-configured cyan is. The visible result is theme drift between content rendered through ghostty-opentui and content rendered directly by the host terminal.

This PR adds a small TS-side hook that lets consumers project ghostty's palette onto the host's:

```ts
import { setBaseColorRemap } from \"ghostty-opentui/terminal-buffer\"

// after probing the host's 0-15 palette via OSC 4
setBaseColorRemap(new Map([
  [\"#8abeb7\", \"#14a0a0\"],  // ghostty cyan → host's saturated teal
  [\"#81a2be\", \"#1844a0\"],  // ghostty blue → host's saturated blue
  // …
]))
```

`convertSpanToChunk` consults the map (if installed) before calling `RGBA.fromHex`. Default is null — pure pass-through, zero effect on existing consumers. Pass null to clear.

## Why a TS-side remap rather than a Zig palette override?

Either approach would solve the problem, but the TS hook is dramatically smaller and lower-risk:
- **No Zig changes.** No native rebuild for 5 platforms (linux/darwin/win × x64/arm64).
- **Backwards-compatible.** Default-null means existing consumers see zero behavior change.
- **Composes cleanly.** The remap runs on lowercase `#rrggbb` strings produced by `lib.zig`'s `writeColor`, which is a stable internal contract.

The trade-off: collisions with explicit truecolor RGB (`\x1b[38;2;r;g;b m`) that *happen* to match one of ghostty's 16 base palette entries will also be remapped. Probability: 16 / 16M, and the failure mode is benign — a single pixel takes the host's same-named color instead of the exact byte match the program emitted.

## Tests

Three integration tests under `setBaseColorRemap` in `terminal-buffer.test.tsx`, exercised via `captureSpans()`:

1. Remap rewrites matching foreground colors (cyan → user's teal)
2. No remap installed → ghostty's default cyan passes through
3. Partial remap → unmatched colors pass through unchanged

All 35 tests in `terminal-buffer.test.tsx` pass. The two pre-existing failures in `git-test.tsx` (\"git log/diff with colors\") are environmental and unrelated to this change — they fail on a fresh clone of `main` as well.

## Real-world use

Currently shipping via patch in [honeymux](https://github.com/honeymux/honeymux/issues/31), an outer-terminal-multiplexer that hosts tmux. Without this hook, fish's stock cyan/blue/teal prompt colors render with ghostty-vt's Tomorrow Night theme regardless of the host terminal (Alacritty, Kitty, Ghostty itself with a different config, etc.). With it, the host's user-configured palette is preserved end-to-end.