### PR TITLE
fix: native-paint rounded box-drawing corners as arcs

### DIFF
--- a/.changeset/rounded-box-corners.md
+++ b/.changeset/rounded-box-corners.md
@@ -1,0 +1,7 @@
+---
+"ghostty-opentui": patch
+---
+
+Native-paint rounded box-drawing corners (`╭ ╮ ╯ ╰`) as SVG arcs.
+
+Previously these characters fell back to font text while the adjacent `─`/`│` lines were drawn natively (centered in the cell), so the corners never connected to the lines — leaving visible gaps and stubs that got worse as line height increased. They are now rendered as quadratic arcs whose endpoints land on the cell edge midpoints, matching where the straight box lines connect, so rounded boxes render as clean, continuous shapes at any line height.

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -344,6 +344,41 @@ describe("rendering options", () => {
     `)
   })
 
+  it("opentui frame to svg — paints rounded box-drawing corners as arcs", () => {
+    const frame: OpenTuiCapturedFrame = {
+      cols: 3,
+      rows: 2,
+      cursor: [0, 0],
+      lines: [
+        { spans: [{ text: "╭─╮", fg: rgba("#ffffff"), bg: transparent(), attributes: 0, width: 3 }] },
+        { spans: [{ text: "╰─╯", fg: rgba("#ffffff"), bg: transparent(), attributes: 0, width: 3 }] },
+      ],
+    }
+
+    const svg = renderOpenTuiToSvg(frame, {
+      fontSize: 10,
+      lineHeight: 1,
+      theme: { background: "#000000", text: "#ffffff" },
+    })
+
+    expect(svg.replaceAll("><", ">\n<")).toMatchInlineSnapshot(`
+      "<svg xmlns="http://www.w3.org/2000/svg" width="18" height="20" viewBox="0 0 18 20">
+      <rect x="0" y="0" width="18" height="20" fill="#000000"/>
+      <rect x="0" y="0" width="18" height="20" fill="#000000"/>
+      <rect x="0" y="0" width="18" height="10" fill="#000000"/>
+      <path d="M 6 5 Q 3 5 3 10" fill="none" stroke="#ffffff" stroke-width="1" stroke-linecap="round"/>
+      <line x1="9" y1="5" x2="12" y2="5" stroke="#ffffff" stroke-width="1" stroke-linecap="butt"/>
+      <line x1="6" y1="5" x2="9" y2="5" stroke="#ffffff" stroke-width="1" stroke-linecap="butt"/>
+      <path d="M 12 5 Q 15 5 15 10" fill="none" stroke="#ffffff" stroke-width="1" stroke-linecap="round"/>
+      <rect x="0" y="10" width="18" height="10" fill="#000000"/>
+      <path d="M 3 10 Q 3 15 6 15" fill="none" stroke="#ffffff" stroke-width="1" stroke-linecap="round"/>
+      <line x1="9" y1="15" x2="12" y2="15" stroke="#ffffff" stroke-width="1" stroke-linecap="butt"/>
+      <line x1="6" y1="15" x2="9" y2="15" stroke="#ffffff" stroke-width="1" stroke-linecap="butt"/>
+      <path d="M 15 10 Q 15 15 12 15" fill="none" stroke="#ffffff" stroke-width="1" stroke-linecap="round"/>
+      </svg>"
+    `)
+  })
+
   it("opentui frame to png", async () => {
     const frame: OpenTuiCapturedFrame = {
       cols: 4,

--- a/src/image.ts
+++ b/src/image.ts
@@ -426,6 +426,20 @@ type BoxSide = "light" | "heavy" | "double" | undefined
 
 function boxDrawingSvg(options: GlyphOptions): string | undefined {
   const { char, x, y, width, height, color } = options
+  const cx = x + width / 2
+  const cy = y + height / 2
+  const light = Math.max(1, Math.round(Math.min(width, height) / 10))
+  const heavy = light * 2
+
+  const arcs: Record<string, string> = {
+    "╭": `M ${x + width} ${cy} Q ${cx} ${cy} ${cx} ${y + height}`,
+    "╮": `M ${x} ${cy} Q ${cx} ${cy} ${cx} ${y + height}`,
+    "╯": `M ${cx} ${y} Q ${cx} ${cy} ${x} ${cy}`,
+    "╰": `M ${cx} ${y} Q ${cx} ${cy} ${x + width} ${cy}`,
+  }
+  const arcPath = arcs[char]
+  if (arcPath) return `<path d="${arcPath}" fill="none" stroke="${escapeXml(color)}" stroke-width="${light}" stroke-linecap="round"/>`
+
   const lines: Record<string, [BoxSide, BoxSide, BoxSide, BoxSide]> = {
     "─": [undefined, "light", undefined, "light"], "━": [undefined, "heavy", undefined, "heavy"],
     "│": ["light", undefined, "light", undefined], "┃": ["heavy", undefined, "heavy", undefined],
@@ -446,10 +460,6 @@ function boxDrawingSvg(options: GlyphOptions): string | undefined {
   if (!sides) return undefined
 
   const [up, right, down, left] = sides
-  const cx = x + width / 2
-  const cy = y + height / 2
-  const light = Math.max(1, Math.round(Math.min(width, height) / 10))
-  const heavy = light * 2
   const drawSide = (options: { side: BoxSide; x1: number; y1: number; x2: number; y2: number }) => {
     const { side, x1, y1, x2, y2 } = options
     if (!side) return ""


### PR DESCRIPTION
## Problem

The rounded box-drawing corners (`╭ ╮ ╯ ╰`) have no native painter in `boxDrawingSvg`, so they fall back to the bundled font. Their neighbours `─` and `│` are painted natively as straight lines through the cell's vertical/horizontal center, so the font corners never meet the native lines. The result is visible gaps and stubs where a rounded box should close, and it gets worse as line height grows (the font glyph stays ~1em while the native lines track the taller cell).

## Fix

Paint the four rounded corners as quadratic-Bezier arcs whose control point is the cell center. Each arc's endpoints land on the cell edge midpoints, which is exactly where the straight box lines connect (`─` at `cy`, `│` at `cx`). So the arcs join the existing native lines seamlessly and tile across rows at any line height.

## Testing

- Added an inline-snapshot test (`paints rounded box-drawing corners as arcs`) that asserts the arc paths share endpoints with the native `─` segments.
- `bun test src/image.test.ts` -> 34 pass, 0 fail.
- `bun tsc --noEmit` -> clean.
- Added a `patch` changeset.
